### PR TITLE
Promised format refactoring

### DIFF
--- a/Alt Liivs/Christmas Liiv.md
+++ b/Alt Liivs/Christmas Liiv.md
@@ -1,32 +1,32 @@
-# Liivya (she/they)
-medium humanoid (_Anime cat-girl_), neutral good
+# Christmas Liivya (she/they)
+_Medium humanoid (_Anime cat-girl_), neutral good_
+
 Blankie Monster 3, Happy Camper 4, Holiday Spirit 3
 
--------------------------------------------------------------------------------
+---
 
-Armor Class 11 (warm sweater)
-Hit Points 69 
-Speed 0ft (stays under blankie)
+**Armor Class** 11 (warm sweater)
 
---------------------------------------------------------------------------
+**Hit Points** 69
 
+**Speed** 0ft (stays under blankie)
 
-| Strength | Dexterity | Constitution | Intelligence | Wisdom | Charisma |
-| -------- | --------- | ------------ | ------------ | ------ | -------- |
-|   10     |     6     |       14     |      18      |  17    |   20     |
+---
 
--------------------------------------------------------------------------------
+## Attributes
+Strength | Dexterity | Constitution | Intelligence | Wisdom | Charisma
+:-:|:-:|:-:|:-:|:-:|:-:
+10(+0) | 6(-2) | 14(+2) | 18(+4) | 17(+3) | 20(+5)
 
-Resistances: Cold
-Vulnerabilities: Christmas sweets, Mr. Grace
-Conditions: Jolly
+## Skills
+**Resistances**: Cold
 
---------------------------------------------------------------------------
+**Vulnerabilities**: Christmas sweets, Mr. Grace
 
-#### It's Crimuh:
-It's Crimuh and Liivya likes Crimuh. That's about it.
+**Conditions**: Jolly
 
-#### Cold is the Devil:
-Outside doesnt exist, Liivya will stay inside where its warm and cozy.
+## Abilities
 
-**christmas cheer, lift spirits make people happy, bard**
+**It's Crimuh**: It's Crimuh and Liivya likes Crimuh. That's about it.
+
+**Cold is the Devil**: Outside doesnt exist, Liivya will stay inside where its warm and cozy.

--- a/Alt Liivs/Librarian Liiv.md
+++ b/Alt Liivs/Librarian Liiv.md
@@ -1,39 +1,39 @@
-# Liivya (she/they)
-Medium humanoid (_Anime cat-girl_), true neutral
+# Librarian Liivya (she/they)
+_Medium humanoid (_Anime cat-girl_), true neutral_
+
 Wizard 19 (Order of Scribes), Warlock 1 (Celestial)
 
--------------------------------------------------------------------------------
+---
 
-Armor Class 20 (magical armor)
-Hit Points 69
-Speed 25ft
+**Armor Class** 20 (magical armor)
 
---------------------------------------------------------------------------
+**Hit Points** 69
 
+**Speed** 25ft
 
-| Strength | Dexterity | Constitution | Intelligence | Wisdom | Charisma |
-| -------- | --------- | ------------ | ------------ | ------ | -------- |
-| 10       | 10        | 10           | 20           | 10     | 10       |
+---
 
--------------------------------------------------------------------------------
+## Attributes
+Strength | Dexterity | Constitution | Intelligence | Wisdom | Charisma
+:-:|:-:|:-:|:-:|:-:|:-:
+10(+0) | 10(+0) | 10(+0) | 20(+5) | 10(+0) | 10(+0)
 
-Skills and Tools: +7 Perception , +9 Religion, +14 History, Scribes Tools
-Resistances: Ego Damage
-Conditions: Forced Neutrality
+## Skills
+**Skills and Tools**: +7 Perception , +9 Religion, +14 History, Scribes Tools
 
---------------------------------------------------------------------------
+**Resistances**: Ego Damage
 
-#### Rule out the Wicked
-Through the power of her statistics skill, Liiv can successfully identify false claims in academic work and day to day conversations, and smite the liars with a trusty wooden ruler.
+**Conditions**: Forced Neutrality
 
-#### Pre-de-doxification
-%%
-Get it, Prestidigitation? XD
-%%
-Well set boundaries and good self insight help Liiv not to dox herself and oftentimes prevent others from doing the same.
+## Abilities
+**Rule out the Wicked**: Through the power of her statistics skill, Liiv can successfully identify false claims in academic work and day to day conversations, and smite the liars with a trusty wooden ruler.
 
-#### Sixth Sense
-Feline arcanum brings about Liiv unhuman abilities. For extended periods of time she gains the ability to reply to every message, greet every chatter, welcome every raid, and shout out every fellow content creator. It's a sight to behold, and a frightening one at that.
+**Pre-de-doxification**: Well set boundaries and good self insight help Liiv not to dox herself and oftentimes prevent others from doing the same.
 
-#### Records of the World
-The Liibrarian is the custodian of the records of the world. Their library contains everything that has ever happened. A friendly creature may request permission to enter the library and search for anything they desire. Any creature in the library gain a +5 bonus to any History, Arcana, Religion and Investigation check.
+**Sixth Sense**: Feline arcanum brings about Liiv unhuman powers. For extended periods of time she gains the ability to reply to every message, greet every chatter, welcome every raid, and shout out every fellow content creator.
+It's a sight to behold, and a frightening one at that.
+
+**Records of the World**: The Liibrarian is the custodian of the records of the world.
+Their library contains everything that has ever happened.
+A friendly creature may request permission to enter the library and search for anything they desire.
+Any creature in the library gain a +5 bonus to any History, Arcana, Religion and Investigation check.

--- a/Alt Liivs/Maid Liiv.md
+++ b/Alt Liivs/Maid Liiv.md
@@ -1,28 +1,31 @@
-# Liivya (she/they)
-Small humanoid (_Anime cat-girl_), lawful good
-paladin 1 (oath of devotion), maid 19 (perfect maid)
+# Maid Liivya (she/they)
+_Small humanoid (_Anime cat-girl_), lawful good_
 
--------------------------------------------------------------------------------
+Paladin 1 (Oath of Devotion), Maid 19 (Perfect Maid)
 
-Armor Class 40 (maid outfit)
-Hit Points Yes 
-Speed 30ft
+---
 
--------------------------------------------------------------------------------
+**Armor Class** 40 (maid outfit)
 
-| Strength | Dexterity | Constitution | Intelligence | Wisdom | Charisma |
-| -------- | --------- | ------------ | ------------ | ------ | -------- |
-|   10     | 18        | 12           | 15           | 15     | 17       |
+**Hit Points** Yes
 
--------------------------------------------------------------------------------
-Skills and Tools: +20 Cleaning, +20 Cooking, duster, mop
-Vulnerabilities: Dust, Dirt
-Conditions: Motivated
+**Speed** 30ft
 
--------------------------------------------------------------------------------
+---
 
-#### Perfect Maid: 
-As a bonus action the Maid can clean a 200ft sphere around her. It is perfect, not a speck of dust remains. 
+## Attributes
+Strength | Dexterity | Constitution | Intelligence | Wisdom | Charisma
+:-:|:-:|:-:|:-:|:-:|:-:
+10(+0) | 18(+4) | 12(+1) | 15(+2) | 15(+2) | 17(+3)
 
-#### Window into the Universe
-The Maid outfit features a window that shows the meaning of the universe.
+## Skills
+**Skills and Tools**: +20 Cleaning, +20 Cooking, duster, mop
+
+**Vulnerabilities**: Dust, Dirt
+
+**Conditions**: Motivated
+
+## Abilities
+**Perfect Maid**: As a bonus action the Maid can clean a 200ft sphere around her. It is perfect, not a speck of dust remains.
+
+**Window into the Universe**: The Maid outfit features a window that shows the meaning of the universe.

--- a/Liivya.md
+++ b/Liivya.md
@@ -1,9 +1,9 @@
 # Liivya (she/they)
-_Tiny humanoid (Anime cat-girl), neutral good_
+_Tiny humanoid (Anime cat-girl), lawful good_
 
 Gremlin 3 (Internet Gremlin), Survivalist 7 (Hardcore survivor), Builder 5 (School of Pastels), Druid 5 (Circle of the Moss)
 
--------------------------------------------------------------------------------
+---
 
 **Armor Class** 14 (jiggly natural armor)
 
@@ -11,17 +11,20 @@ Gremlin 3 (Internet Gremlin), Survivalist 7 (Hardcore survivor), Builder 5 (Scho
 
 **Speed** 20ft (tiny legs)
 
--------------------------------------------------------------------------------
+---
 
 ## Attributes
-| Strength | Dexterity | Constitution | Intelligence | Wisdom | Charisma |
-| -------- | --------- | ------------ | ------------ | ------ | -------- |
-|  11(+0)  |   6(-2)   |    14(+2)    |    20(+5)    | 18(+4) |  17(+3)  |
+Strength | Dexterity | Constitution | Intelligence | Wisdom | Charisma
+:-:|:-:|:-:|:-:|:-:|:-:
+11(+0) | 6(-2) | 14(+2) | 20(+5) | 18(+4) | 17(+3)
 
 ## Skills
 **Skills and Tools**: -3 Acrobatics, +7 Insight, +9 Performance, Broadcasting Software
+
 **Resistances**: Children, Bigots, Flirting
+
 **Vulnerabilities**: Maccas, Math, Temperature, Databases, Cats
+
 **Conditions**: Exhaustion (chronic)
 
 ## Abilities
@@ -34,5 +37,7 @@ which gives her **Frightful Presence**.
 
 ## Feats
 **Ranter**: Able to rant about any topic, in depth, with great vigor and passion.
+
 **Matchmaker**: has the ability to bring chatters together for true love.
+
 **Autrizzim**: +3 charisma when interacting with another autistic person.

--- a/Liivya.md
+++ b/Liivya.md
@@ -7,7 +7,7 @@ Gremlin 3 (Internet Gremlin), Survivalist 7 (Hardcore survivor), Builder 5 (Scho
 
 **Armor Class** 14 (jiggly natural armor)
 
-**Hit Points** 69 
+**Hit Points** 69
 
 **Speed** 20ft (tiny legs)
 

--- a/Mr. Grace.md
+++ b/Mr. Grace.md
@@ -1,36 +1,35 @@
-small beast (feline), chaotic neutral
+# Mr. Grace
+_Small beast (feline), chaotic neutral_
 
----------------------------------------- 
+---
 
-Armor Class: 10 (natural armor)
-Speed: 15ft, 55ft (zoomies only)
+**Armor Class**: 10 (natural armor)
 
-----------------------------------------
+**Speed**: 15ft, 55ft (zoomies only)
 
+---
 
-| Strength | Dexterity | Constitution | Intelligence | Wisdom | Charisma |
-| -------- | --------- | ------------ | ------------ | ------ | -------- |
-| 10       | 6         | 14           | 18           | 17     | 20       |
+## Attributes
+Strength | Dexterity | Constitution | Intelligence | Wisdom | Charisma
+:-:|:-:|:-:|:-:|:-:|:-:
+10(+0) | 6(-2) | 14(+2) | 18(+4) | 17(+3) | 20(+5)
 
-----------------------------------------
-Senses: passive Perception 15 (can see into the ethereal Plane)
-Languages: Yes 
-Skills and Tools: +10 Stealth 
-Conditions: Asleep (probably), Hungry (definitely) 
+## Skills
+**Senses**: passive Perception 15 (can see into the Ethereal Plane)
 
----------------------------------------- 
-#### Majestic:
-All friendly humanoid have disadvantage in denying Mr. Grace anything he desires. 
+**Languages**: Yes 
 
-#### Cat Cam:
-Mr. Grace's patron maybe summon Mr. Grace to display to all creatures. Any Creature that sees Mr. Grace is charmed by him.
+**Skills and Tools**: +10 Stealth 
 
-#### Just a little guy:
-He is just a little guy
+**Conditions**: Asleep (probably), Hungry (definitely) 
 
----------------------------------------- 
-#### Actions:
-Murder mittens: Mr. Grace always stays strapped, if you dare to cross him or he just feels like it, he can attack you with the in-built murder mittens dealing 1d4 slashing damage and 1d8 psychic damage.
+## Abilities
+**Majestic**: All friendly humanoids have disadvantage in denying Mr. Grace anything he desires.
 
----------------------------------------- 
-#### Familiar: [[Mr. Grace]]
+**Cat Cam**: Mr. Grace's patron may summon Mr. Grace to display to all creatures.
+Any creature that sees Mr. Grace is charmed by him.
+
+**Just a little guy**: He is just a little guy.
+
+**Murder mittens**: Mr. Grace always stays strapped.
+If you dare to cross him or he just feels like it, he can attack you with the in-built murder mittens dealing 1d4 slashing damage and 1d8 psychic damage.


### PR DESCRIPTION
- Extra newlines were inserted to make sure skill and feat entries are each displayed on a separate line.
- Table syntax was minimized to make further editing less burdensome.
- Ability scores and modifiers are now centered within the table cells. Used `:----:` syntax to achieve this effect.
- Took the libery of specifying what outfit the sheet refers to in the first heading.

Other then that, I just refined the format from the stat block Liiv showed in Discord and populated all sheets within `Alt Liivs` folder with that format.